### PR TITLE
Add group posting moderation API

### DIFF
--- a/Modules/Groups/App/Http/Controllers/PostingModerationController.php
+++ b/Modules/Groups/App/Http/Controllers/PostingModerationController.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Modules\Groups\App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Modules\SocialMedia\App\Models\Post;
+use Modules\SocialMedia\App\Models\DetailPost;
+
+class PostingModerationController extends Controller
+{
+    public function moderate(Request $request, $group_id, $post_id): JsonResponse
+    {
+        try {
+            DB::beginTransaction();
+            $post = Post::where('t_small_groups_id', $group_id)->findOrFail($post_id);
+            $post->moderation = [
+                'moderator' => $request->user(),
+                'reason'    => $request->input('reason'),
+            ];
+            $post->save();
+            $post->delete();
+            DB::commit();
+
+            return response()->json([
+                'status'  => 'success',
+                'message' => 'Post moderated successfully.',
+            ]);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'status' => 'failed',
+                'error'  => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function listComments($group_id, $post_id): JsonResponse
+    {
+        $comments = DetailPost::where('id_post', $post_id)
+            ->whereNull('parent_id')
+            ->get();
+
+        return response()->json([
+            'status' => 'success',
+            'data'   => $comments,
+        ]);
+    }
+
+    public function storeComment(Request $request, $group_id, $post_id): JsonResponse
+    {
+        try {
+            DB::beginTransaction();
+            $comment = DetailPost::create([
+                'id_post'  => $post_id,
+                'id_user'  => $request->user()->id,
+                'komentar' => $request->input('content'),
+            ]);
+            DB::commit();
+            return response()->json([
+                'status' => 'success',
+                'data'   => $comment,
+            ], 201);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'status' => 'failed',
+                'error'  => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function updateComment(Request $request, $group_id, $post_id, $comment_id): JsonResponse
+    {
+        try {
+            DB::beginTransaction();
+            $comment = DetailPost::where('id_post', $post_id)
+                ->where('id', $comment_id)
+                ->firstOrFail();
+            $comment->komentar = $request->input('content');
+            $comment->save();
+            DB::commit();
+            return response()->json([
+                'status' => 'success',
+                'data'   => $comment,
+            ]);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'status' => 'failed',
+                'error'  => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function destroyComment($group_id, $post_id, $comment_id): JsonResponse
+    {
+        try {
+            DB::beginTransaction();
+            $comment = DetailPost::where('id_post', $post_id)
+                ->where('id', $comment_id)
+                ->firstOrFail();
+            $comment->delete();
+            DB::commit();
+            return response()->json([
+                'status'  => 'success',
+                'message' => 'Comment deleted successfully.',
+            ]);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'status' => 'failed',
+                'error'  => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function listSubcomments($group_id, $post_id, $comment_id): JsonResponse
+    {
+        $subcomments = DetailPost::where('parent_id', $comment_id)->get();
+
+        return response()->json([
+            'status' => 'success',
+            'data'   => $subcomments,
+        ]);
+    }
+
+    public function storeSubcomment(Request $request, $group_id, $post_id, $comment_id): JsonResponse
+    {
+        try {
+            DB::beginTransaction();
+            $subcomment = DetailPost::create([
+                'id_post'  => $post_id,
+                'id_user'  => $request->user()->id,
+                'komentar' => $request->input('content'),
+                'parent_id' => $comment_id,
+            ]);
+            DB::commit();
+            return response()->json([
+                'status' => 'success',
+                'data'   => $subcomment,
+            ], 201);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'status' => 'failed',
+                'error'  => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function updateSubcomment(Request $request, $group_id, $post_id, $comment_id, $subcomment_id): JsonResponse
+    {
+        try {
+            DB::beginTransaction();
+            $subcomment = DetailPost::where('parent_id', $comment_id)
+                ->where('id', $subcomment_id)
+                ->firstOrFail();
+            $subcomment->komentar = $request->input('content');
+            $subcomment->save();
+            DB::commit();
+            return response()->json([
+                'status' => 'success',
+                'data'   => $subcomment,
+            ]);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'status' => 'failed',
+                'error'  => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function destroySubcomment($group_id, $post_id, $comment_id, $subcomment_id): JsonResponse
+    {
+        try {
+            DB::beginTransaction();
+            $subcomment = DetailPost::where('parent_id', $comment_id)
+                ->where('id', $subcomment_id)
+                ->firstOrFail();
+            $subcomment->delete();
+            DB::commit();
+            return response()->json([
+                'status'  => 'success',
+                'message' => 'Subcomment deleted successfully.',
+            ]);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'status' => 'failed',
+                'error'  => $e->getMessage(),
+            ], 500);
+        }
+    }
+}
+

--- a/Modules/Groups/routes/api.php
+++ b/Modules/Groups/routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Modules\Groups\App\Http\Controllers\GroupsController;
 use Modules\Groups\App\Http\Controllers\PostingController;
+use Modules\Groups\App\Http\Controllers\PostingModerationController;
 
 /*
     |--------------------------------------------------------------------------
@@ -39,6 +40,18 @@ Route::middleware('auth:api')->group(function () {
             Route::get('{group_id}/{id}', [PostingController::class, 'show']);
             Route::post('update/{group_id}/{id}', [PostingController::class, 'update']);
             Route::delete('delete/{group_id}/{id}', [PostingController::class, 'destroy']);
+
+            Route::prefix('{group_id}/{post_id}')->group(function() {
+                Route::put('moderate', [PostingModerationController::class, 'moderate']);
+                Route::get('comments', [PostingModerationController::class, 'listComments']);
+                Route::post('comments', [PostingModerationController::class, 'storeComment']);
+                Route::put('comments/{comment_id}', [PostingModerationController::class, 'updateComment']);
+                Route::delete('comments/{comment_id}', [PostingModerationController::class, 'destroyComment']);
+                Route::get('comments/{comment_id}/replies', [PostingModerationController::class, 'listSubcomments']);
+                Route::post('comments/{comment_id}/replies', [PostingModerationController::class, 'storeSubcomment']);
+                Route::put('comments/{comment_id}/replies/{subcomment_id}', [PostingModerationController::class, 'updateSubcomment']);
+                Route::delete('comments/{comment_id}/replies/{subcomment_id}', [PostingModerationController::class, 'destroySubcomment']);
+            });
 
         });
     });


### PR DESCRIPTION
## Summary
- implement `PostingModerationController` for group post moderation
- expose moderation and comment management endpoints under `groups/posting`
- ensure tests pass

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68537a3f283483308049e803fa50350b